### PR TITLE
メンバーの情報を表示するコンポーネントを改善

### DIFF
--- a/client/src/components/MemberInfo/MemberInfo.tsx
+++ b/client/src/components/MemberInfo/MemberInfo.tsx
@@ -1,3 +1,5 @@
+import styles from './memberInfo.module.css';
+
 type value = string | number | boolean | null | undefined | value[] | { [key: string]: value };
 
 type Props = {
@@ -6,7 +8,7 @@ type Props = {
 };
 
 // eslint-disable-next-line complexity
-const valueComponent = (value: value) => {
+const valueComponent = (value: value, level: number) => {
   if (typeof value === 'string') {
     return stringComponent(value);
   } else if (typeof value === 'number') {
@@ -18,15 +20,15 @@ const valueComponent = (value: value) => {
   } else if (value === undefined) {
     return undefinedComponent();
   } else if (Array.isArray(value)) {
-    return arrayComponent(value);
+    return arrayComponent(value, level + 1);
   } else {
-    return objectComponent(value);
+    return objectComponent(value, level + 1);
   }
 };
 
 const stringComponent = (value: string) => {
   return (
-    <span>
+    <span className={styles.string}>
       {`"`}
       {value}
       {`"`}
@@ -50,40 +52,43 @@ const undefinedComponent = () => {
   return <span>undefined</span>;
 };
 
-const arrayComponent = (value: value[]) => {
+const arrayComponent = (value: value[], level: number) => {
+  const bracketLevel = ((level % 3) + 1) as 1 | 2 | 3;
   return (
     <span>
-      {'['}
+      <span className={styles[`bracket-${bracketLevel}`]}>{'['}</span>
       {value.map((v, i) => (
         <span key={i}>
-          {valueComponent(v)}
+          {valueComponent(v, level + 1)}
           {i !== value.length - 1 && ', '}
         </span>
       ))}
-      {']'}
+      <span className={styles[`bracket-${bracketLevel}`]}>{']'}</span>
     </span>
   );
 };
 
-const objectComponent = (value: { [key: string]: value }) => {
+const objectComponent = (value: { [key: string]: value }, level: number) => {
+  const bracketLevel = ((level % 3) + 1) as 1 | 2 | 3;
   return (
     <span>
-      {'{'}
+      <span className={styles[`bracket-${bracketLevel}`]}>{'{'}</span>
       {Object.entries(value).map(([k, v], i) => (
         <span key={i}>
-          <span>{k}</span>: {valueComponent(v)}
+          <span className={styles.key}>{k}:</span> {valueComponent(v, level + 1)}
           {i !== Object.entries(value).length - 1 && ', '}
         </span>
       ))}
-      {'}'}
+      <span className={styles[`bracket-${bracketLevel}`]}>{'}'}</span>
     </span>
   );
 };
 
 const MemberInfo = ({ value, name }: Props) => {
   return (
-    <div>
-      <span>const</span> <span>{name}</span> = {valueComponent(value)};
+    <div className={styles.info}>
+      <span className={styles.const}>const</span> <span className={styles.name}>{name}</span> ={' '}
+      {valueComponent(value, 1)};
     </div>
   );
 };

--- a/client/src/components/MemberInfo/MemberInfo.tsx
+++ b/client/src/components/MemberInfo/MemberInfo.tsx
@@ -8,7 +8,7 @@ type Props = {
 };
 
 // eslint-disable-next-line complexity
-const valueComponent = (value: value, level: number) => {
+const valueComponent = (value: value, level: number, indent: number) => {
   if (typeof value === 'string') {
     return stringComponent(value);
   } else if (typeof value === 'number') {
@@ -20,9 +20,9 @@ const valueComponent = (value: value, level: number) => {
   } else if (value === undefined) {
     return undefinedComponent();
   } else if (Array.isArray(value)) {
-    return arrayComponent(value, level + 1);
+    return arrayComponent(value, level + 1, indent);
   } else {
-    return objectComponent(value, level + 1);
+    return objectComponent(value, level + 1, indent);
   }
 };
 
@@ -41,45 +41,54 @@ const numberComponent = (value: number) => {
 };
 
 const booleanComponent = (value: boolean) => {
-  return <span>{value ? 'true' : 'false'}</span>;
+  return <span className={styles.boolean}>{value ? 'true' : 'false'}</span>;
 };
 
 const nullComponent = () => {
-  return <span>null</span>;
+  return <span className={styles.null}>null</span>;
 };
 
 const undefinedComponent = () => {
-  return <span>undefined</span>;
+  return <span className={styles.undefined}>undefined</span>;
 };
 
-const arrayComponent = (value: value[], level: number) => {
+const arrayComponent = (value: value[], level: number, indent: number) => {
   const bracketLevel = ((level % 3) + 1) as 1 | 2 | 3;
+  const child = value[0];
+  const isArray = Array.isArray(child);
   return (
     <span>
       <span className={styles[`bracket-${bracketLevel}`]}>{'['}</span>
       {value.map((v, i) => (
-        <span key={i}>
-          {valueComponent(v, level + 1)}
+        <span key={i} style={{ display: isArray ? 'block' : 'inline' }}>
+          {isArray && '  '.repeat(indent + 1)}
+          {valueComponent(v, level + 1, indent + (isArray ? 1 : 0))}
           {i !== value.length - 1 && ', '}
         </span>
       ))}
-      <span className={styles[`bracket-${bracketLevel}`]}>{']'}</span>
+      <span className={styles[`bracket-${bracketLevel}`]}>
+        {isArray && '  '.repeat(indent)}
+        {']'}
+      </span>
     </span>
   );
 };
 
-const objectComponent = (value: { [key: string]: value }, level: number) => {
+const objectComponent = (value: { [key: string]: value }, level: number, indent: number) => {
   const bracketLevel = ((level % 3) + 1) as 1 | 2 | 3;
   return (
     <span>
       <span className={styles[`bracket-${bracketLevel}`]}>{'{'}</span>
       {Object.entries(value).map(([k, v], i) => (
-        <span key={i}>
-          <span className={styles.key}>{k}:</span> {valueComponent(v, level + 1)}
-          {i !== Object.entries(value).length - 1 && ', '}
-        </span>
+        <div key={i}>
+          {'  '.repeat(indent + 1)}
+          <span className={styles.key}>{k}:</span> {valueComponent(v, level + 1, indent + 1)},
+        </div>
       ))}
-      <span className={styles[`bracket-${bracketLevel}`]}>{'}'}</span>
+      <span className={styles[`bracket-${bracketLevel}`]}>
+        {Object.keys(value).length > 0 && '  '.repeat(indent)}
+        {'}'}
+      </span>
     </span>
   );
 };
@@ -88,7 +97,7 @@ const MemberInfo = ({ value, name }: Props) => {
   return (
     <div className={styles.info}>
       <span className={styles.const}>const</span> <span className={styles.name}>{name}</span> ={' '}
-      {valueComponent(value, 1)};
+      {valueComponent(value, 1, 0)};
     </div>
   );
 };

--- a/client/src/components/MemberInfo/MemberInfo.tsx
+++ b/client/src/components/MemberInfo/MemberInfo.tsx
@@ -37,7 +37,7 @@ const stringComponent = (value: string) => {
 };
 
 const numberComponent = (value: number) => {
-  return <span>{value}</span>;
+  return <span className={styles.number}>{value}</span>;
 };
 
 const booleanComponent = (value: boolean) => {

--- a/client/src/components/MemberInfo/MemberInfo.tsx
+++ b/client/src/components/MemberInfo/MemberInfo.tsx
@@ -37,21 +37,17 @@ const StringComponent = ({ value }: { value: string }) => {
   );
 };
 
-const NumberComponent = ({ value }: { value: number }) => {
-  return <span className={styles.number}>{value}</span>;
-};
+const NumberComponent = ({ value }: { value: number }) => (
+  <span className={styles.number}>{value}</span>
+);
 
-const BooleanComponent = ({ value }: { value: boolean }) => {
-  return <span className={styles.boolean}>{value ? 'true' : 'false'}</span>;
-};
+const BooleanComponent = ({ value }: { value: boolean }) => (
+  <span className={styles.boolean}>{value ? 'true' : 'false'}</span>
+);
 
-const NullComponent = () => {
-  return <span className={styles.null}>null</span>;
-};
+const NullComponent = () => <span className={styles.null}>null</span>;
 
-const UndefinedComponent = () => {
-  return <span className={styles.undefined}>undefined</span>;
-};
+const UndefinedComponent = () => <span className={styles.undefined}>undefined</span>;
 
 type ArrayProps = {
   value: value[];

--- a/client/src/components/MemberInfo/MemberInfo.tsx
+++ b/client/src/components/MemberInfo/MemberInfo.tsx
@@ -8,21 +8,21 @@ type Props = {
 };
 
 // eslint-disable-next-line complexity
-const valueComponent = (value: value, level: number, indent: number) => {
+const ValueComponent = (value: value, level: number, indent: number) => {
   if (typeof value === 'string') {
     return stringComponent(value);
   } else if (typeof value === 'number') {
-    return numberComponent(value);
+    return NumberComponent(value);
   } else if (typeof value === 'boolean') {
-    return booleanComponent(value);
+    return BooleanComponent(value);
   } else if (value === null) {
-    return nullComponent();
+    return NullComponent();
   } else if (value === undefined) {
-    return undefinedComponent();
+    return UndefinedComponent();
   } else if (Array.isArray(value)) {
-    return arrayComponent(value, level + 1, indent);
+    return ArrayComponent(value, level + 1, indent);
   } else {
-    return objectComponent(value, level + 1, indent);
+    return ObjectComponent(value, level + 1, indent);
   }
 };
 
@@ -36,23 +36,23 @@ const stringComponent = (value: string) => {
   );
 };
 
-const numberComponent = (value: number) => {
+const NumberComponent = (value: number) => {
   return <span className={styles.number}>{value}</span>;
 };
 
-const booleanComponent = (value: boolean) => {
+const BooleanComponent = (value: boolean) => {
   return <span className={styles.boolean}>{value ? 'true' : 'false'}</span>;
 };
 
-const nullComponent = () => {
+const NullComponent = () => {
   return <span className={styles.null}>null</span>;
 };
 
-const undefinedComponent = () => {
+const UndefinedComponent = () => {
   return <span className={styles.undefined}>undefined</span>;
 };
 
-const arrayComponent = (value: value[], level: number, indent: number) => {
+const ArrayComponent = (value: value[], level: number, indent: number) => {
   const bracketLevel = ((level % 3) + 1) as 1 | 2 | 3;
   const child = value[0];
   const isArray = Array.isArray(child);
@@ -62,7 +62,7 @@ const arrayComponent = (value: value[], level: number, indent: number) => {
       {value.map((v, i) => (
         <span key={i} style={{ display: isArray ? 'block' : 'inline' }}>
           {isArray && '  '.repeat(indent + 1)}
-          {valueComponent(v, level + 1, indent + (isArray ? 1 : 0))}
+          {ValueComponent(v, level + 1, indent + (isArray ? 1 : 0))}
           {i !== value.length - 1 && ', '}
         </span>
       ))}
@@ -74,7 +74,7 @@ const arrayComponent = (value: value[], level: number, indent: number) => {
   );
 };
 
-const objectComponent = (value: { [key: string]: value }, level: number, indent: number) => {
+const ObjectComponent = (value: { [key: string]: value }, level: number, indent: number) => {
   const bracketLevel = ((level % 3) + 1) as 1 | 2 | 3;
   return (
     <span>
@@ -82,7 +82,7 @@ const objectComponent = (value: { [key: string]: value }, level: number, indent:
       {Object.entries(value).map(([k, v], i) => (
         <div key={i}>
           {'  '.repeat(indent + 1)}
-          <span className={styles.key}>{k}:</span> {valueComponent(v, level + 1, indent + 1)},
+          <span className={styles.key}>{k}:</span> {ValueComponent(v, level + 1, indent + 1)},
         </div>
       ))}
       <span className={styles[`bracket-${bracketLevel}`]}>
@@ -97,7 +97,7 @@ const MemberInfo = ({ value, name }: Props) => {
   return (
     <div className={styles.info}>
       <span className={styles.const}>const</span> <span className={styles.name}>{name}</span> ={' '}
-      {valueComponent(value, 1, 0)};
+      {ValueComponent(value, 1, 0)};
     </div>
   );
 };

--- a/client/src/components/MemberInfo/MemberInfo.tsx
+++ b/client/src/components/MemberInfo/MemberInfo.tsx
@@ -2,31 +2,32 @@ import styles from './memberInfo.module.css';
 
 type value = string | number | boolean | null | undefined | value[] | { [key: string]: value };
 
-type Props = {
+type ValueProps = {
   value: value;
-  name: string;
+  level: number;
+  indent: number;
 };
 
 // eslint-disable-next-line complexity
-const ValueComponent = (value: value, level: number, indent: number) => {
+const ValueComponent = ({ value, level, indent }: ValueProps) => {
   if (typeof value === 'string') {
-    return stringComponent(value);
+    return <StringComponent value={value} />;
   } else if (typeof value === 'number') {
-    return NumberComponent(value);
+    return <NumberComponent value={value} />;
   } else if (typeof value === 'boolean') {
-    return BooleanComponent(value);
+    return <BooleanComponent value={value} />;
   } else if (value === null) {
-    return NullComponent();
+    return <NullComponent />;
   } else if (value === undefined) {
-    return UndefinedComponent();
+    return <UndefinedComponent />;
   } else if (Array.isArray(value)) {
-    return ArrayComponent(value, level + 1, indent);
+    return <ArrayComponent value={value} level={level + 1} indent={indent} />;
   } else {
-    return ObjectComponent(value, level + 1, indent);
+    return <ObjectComponent value={value} level={level + 1} indent={indent} />;
   }
 };
 
-const stringComponent = (value: string) => {
+const StringComponent = ({ value }: { value: string }) => {
   return (
     <span className={styles.string}>
       {`"`}
@@ -36,11 +37,11 @@ const stringComponent = (value: string) => {
   );
 };
 
-const NumberComponent = (value: number) => {
+const NumberComponent = ({ value }: { value: number }) => {
   return <span className={styles.number}>{value}</span>;
 };
 
-const BooleanComponent = (value: boolean) => {
+const BooleanComponent = ({ value }: { value: boolean }) => {
   return <span className={styles.boolean}>{value ? 'true' : 'false'}</span>;
 };
 
@@ -52,7 +53,13 @@ const UndefinedComponent = () => {
   return <span className={styles.undefined}>undefined</span>;
 };
 
-const ArrayComponent = (value: value[], level: number, indent: number) => {
+type ArrayProps = {
+  value: value[];
+  level: number;
+  indent: number;
+};
+
+const ArrayComponent = ({ value, level, indent }: ArrayProps) => {
   const bracketLevel = ((level % 3) + 1) as 1 | 2 | 3;
   const child = value[0];
   const isArray = Array.isArray(child);
@@ -62,7 +69,7 @@ const ArrayComponent = (value: value[], level: number, indent: number) => {
       {value.map((v, i) => (
         <span key={i} style={{ display: isArray ? 'block' : 'inline' }}>
           {isArray && '  '.repeat(indent + 1)}
-          {ValueComponent(v, level + 1, indent + (isArray ? 1 : 0))}
+          <ValueComponent value={v} level={level + 1} indent={indent + (isArray ? 1 : 0)} />
           {i !== value.length - 1 && ', '}
         </span>
       ))}
@@ -74,7 +81,13 @@ const ArrayComponent = (value: value[], level: number, indent: number) => {
   );
 };
 
-const ObjectComponent = (value: { [key: string]: value }, level: number, indent: number) => {
+type ObjectProps = {
+  value: { [key: string]: value };
+  level: number;
+  indent: number;
+};
+
+const ObjectComponent = ({ value, level, indent }: ObjectProps) => {
   const bracketLevel = ((level % 3) + 1) as 1 | 2 | 3;
   return (
     <span>
@@ -82,7 +95,8 @@ const ObjectComponent = (value: { [key: string]: value }, level: number, indent:
       {Object.entries(value).map(([k, v], i) => (
         <div key={i}>
           {'  '.repeat(indent + 1)}
-          <span className={styles.key}>{k}:</span> {ValueComponent(v, level + 1, indent + 1)},
+          <span className={styles.key}>{k}:</span>{' '}
+          <ValueComponent value={v} level={level + 1} indent={indent + 1} />,
         </div>
       ))}
       <span className={styles[`bracket-${bracketLevel}`]}>
@@ -93,11 +107,16 @@ const ObjectComponent = (value: { [key: string]: value }, level: number, indent:
   );
 };
 
-const MemberInfo = ({ value, name }: Props) => {
+type InfoProps = {
+  value: value;
+  name: string;
+};
+
+const MemberInfo = ({ value, name }: InfoProps) => {
   return (
     <div className={styles.info}>
       <span className={styles.const}>const</span> <span className={styles.name}>{name}</span> ={' '}
-      {ValueComponent(value, 1, 0)};
+      <ValueComponent value={value} level={1} indent={0} />;
     </div>
   );
 };

--- a/client/src/components/MemberInfo/MemberInfo.tsx
+++ b/client/src/components/MemberInfo/MemberInfo.tsx
@@ -1,57 +1,91 @@
-import styles from './memberInfo.module.css';
+type value = string | number | boolean | null | undefined | value[] | { [key: string]: value };
 
-const ArrayComponent = ({ array }: { array: string[] }) => {
+type Props = {
+  value: value;
+  name: string;
+};
+
+// eslint-disable-next-line complexity
+const valueComponent = (value: value) => {
+  if (typeof value === 'string') {
+    return stringComponent(value);
+  } else if (typeof value === 'number') {
+    return numberComponent(value);
+  } else if (typeof value === 'boolean') {
+    return booleanComponent(value);
+  } else if (value === null) {
+    return nullComponent();
+  } else if (value === undefined) {
+    return undefinedComponent();
+  } else if (Array.isArray(value)) {
+    return arrayComponent(value);
+  } else {
+    return objectComponent(value);
+  }
+};
+
+const stringComponent = (value: string) => {
   return (
-    <>
-      <span className={styles.array}>[</span>
-      {array.map((item, index) => {
-        const comma = array.length - 1 === index ? '' : ', ';
-        return (
-          <>
-            <span key={index} className={styles.string}>{`"${item}"`}</span>
-            {comma}
-          </>
-        );
-      })}
-      <span className={styles.array}>]</span>
-    </>
+    <span>
+      {`"`}
+      {value}
+      {`"`}
+    </span>
   );
 };
 
-const ObjectComponent = (object: { [key: string]: string | string[] }) => {
+const numberComponent = (value: number) => {
+  return <span>{value}</span>;
+};
+
+const booleanComponent = (value: boolean) => {
+  return <span>{value ? 'true' : 'false'}</span>;
+};
+
+const nullComponent = () => {
+  return <span>null</span>;
+};
+
+const undefinedComponent = () => {
+  return <span>undefined</span>;
+};
+
+const arrayComponent = (value: value[]) => {
   return (
-    <>
-      <span className={styles.object}>{'{'}</span>
-      {Object.keys(object).map((key, index) => {
-        return (
-          <div key={index}>
-            <span className={styles.key}>{`  ${key}: `}</span>
-            {Array.isArray(object[key]) ? (
-              <ArrayComponent array={object[key] as string[]} />
-            ) : (
-              <span className={styles.string}>{`"${object[key]}"`}</span>
-            )}
-            ,
-          </div>
-        );
-      })}
-      <span className={styles.object}>{'}'};</span>
-    </>
+    <span>
+      {'['}
+      {value.map((v, i) => (
+        <span key={i}>
+          {valueComponent(v)}
+          {i !== value.length - 1 && ', '}
+        </span>
+      ))}
+      {']'}
+    </span>
   );
 };
 
-type PropsInfo = {
-  object: Record<string, string | string[]>;
-  objectName: string;
+const objectComponent = (value: { [key: string]: value }) => {
+  return (
+    <span>
+      {'{'}
+      {Object.entries(value).map(([k, v], i) => (
+        <span key={i}>
+          <span>{k}</span>: {valueComponent(v)}
+          {i !== Object.entries(value).length - 1 && ', '}
+        </span>
+      ))}
+      {'}'}
+    </span>
+  );
 };
 
-const UserInfo = ({ object, objectName }: PropsInfo) => {
+const MemberInfo = ({ value, name }: Props) => {
   return (
-    <div className={styles.info}>
-      <span className={styles.const}>const</span>{' '}
-      <span className={styles.object}>{objectName}</span> = <ObjectComponent {...object} />
+    <div>
+      <span>const</span> <span>{name}</span> = {valueComponent(value)};
     </div>
   );
 };
 
-export default UserInfo;
+export default MemberInfo;

--- a/client/src/components/MemberInfo/memberInfo.module.css
+++ b/client/src/components/MemberInfo/memberInfo.module.css
@@ -1,24 +1,27 @@
 .info {
-  color: #fff;
-  white-space: pre-wrap;
+  color: white;
   font-weight: bold;
+  white-space: pre-wrap;
 }
 
-.array {
-  color: #f700f5;
-}
-.object {
+.name,
+.bracket-1 {
   color: #feff8d;
 }
 
-.const {
-  color: #79a5fb;
+.bracket-2 {
+  color: #fb00fa;
+}
+
+.const,
+.bracket-3 {
+  color: #0078d4;
 }
 
 .key {
-  color: #4ac7f7;
+  color: #89fefe;
 }
 
 .string {
-  color: #eeb371;
+  color: #f3b371;
 }

--- a/client/src/components/MemberInfo/memberInfo.module.css
+++ b/client/src/components/MemberInfo/memberInfo.module.css
@@ -28,3 +28,7 @@
 .string {
   color: #f3b371;
 }
+
+.number {
+  color: #94cea8;
+}

--- a/client/src/components/MemberInfo/memberInfo.module.css
+++ b/client/src/components/MemberInfo/memberInfo.module.css
@@ -14,6 +14,9 @@
 }
 
 .const,
+.null,
+.undefined,
+.boolean,
 .bracket-3 {
   color: #0078d4;
 }


### PR DESCRIPTION
入力したデータを大体の型のものはいい感じに表示できます

(example)
input:
![image](https://github.com/INIAD-Developers/INIADts-jobsite/assets/131662659/8e26a1ba-21c5-4d16-8660-8bdc1a3f291e)
output:
![image](https://github.com/INIAD-Developers/INIADts-jobsite/assets/131662659/b416f7a3-ca48-49ff-aac0-346d278dba45)

デザイン案に近いものは簡単に表現できると思います
(デザイン案)
![image](https://github.com/INIAD-Developers/INIADts-jobsite/assets/131662659/3b4c5b4b-a115-4ab5-9e8c-8d04a5729be7)
