### PR TITLE
s3のメンバーの情報を操作するRepoを追加

### DIFF
--- a/server/commonTypesWithClient/models.ts
+++ b/server/commonTypesWithClient/models.ts
@@ -23,3 +23,12 @@ export type GitHubActivityModel = {
   }[];
   userId: string;
 };
+
+// 仮
+export type MemberModel = {
+  githubId: string;
+  displayName: string;
+  avatarURL?: string;
+  graduate: number;
+  introduction?: string;
+};

--- a/server/commonTypesWithClient/models.ts
+++ b/server/commonTypesWithClient/models.ts
@@ -29,6 +29,7 @@ export type MemberModel = {
   githubId: string;
   displayName: string;
   avatarURL?: string;
-  graduate: number;
+  graduateYear: number;
   introduction?: string;
+  links?: string[];
 };

--- a/server/repository/membersRepository.ts
+++ b/server/repository/membersRepository.ts
@@ -1,0 +1,69 @@
+import type { MemberModel } from '$/commonTypesWithClient/models';
+import { S3_BUCKET } from '$/service/envValues';
+import { s3Client } from '$/service/s3Client';
+import { GetObjectCommand, ListObjectsCommand, PutObjectCommand } from '@aws-sdk/client-s3';
+import { assert } from 'vitest';
+
+export const membersRepository = {
+  upsert: async (memberInfo: MemberModel) => {
+    const s3Params = {
+      Bucket: S3_BUCKET,
+      Key: `members/${memberInfo.githubId}.json`,
+      Body: JSON.stringify(memberInfo),
+    };
+
+    try {
+      const s3Command = new PutObjectCommand(s3Params);
+      await s3Client.send(s3Command);
+    } catch (err) {
+      console.error(err);
+    }
+  },
+  getMemberList: async () => {
+    const s3Params = {
+      Bucket: S3_BUCKET,
+      Prefix: 'members/',
+    };
+
+    try {
+      const s3Command = new ListObjectsCommand(s3Params);
+      const { Contents } = await s3Client.send(s3Command);
+
+      if (Contents === undefined) return [];
+
+      const memberList = await Promise.all(
+        Contents.map(({ Key }) => {
+          assert(Key !== undefined);
+          const githubId = Key.split('/')[1].split('.')[0];
+          return githubId;
+        })
+      );
+
+      return memberList;
+    } catch (err) {
+      console.error(err);
+      return [];
+    }
+  },
+  getMember: async (githubId: string): Promise<MemberModel | null> => {
+    const s3Params = {
+      Bucket: S3_BUCKET,
+      Key: `members/${githubId}.json`,
+    };
+
+    try {
+      const s3Command = new GetObjectCommand(s3Params);
+      const s3Response = await s3Client.send(s3Command);
+
+      if (s3Response.Body === undefined) return null;
+
+      const memberInfoString = await s3Response.Body.transformToString();
+      const memberInfo: MemberModel = JSON.parse(memberInfoString);
+
+      return memberInfo;
+    } catch (err) {
+      console.error(err);
+      return null;
+    }
+  },
+};

--- a/server/repository/membersRepository.ts
+++ b/server/repository/membersRepository.ts
@@ -31,13 +31,11 @@ export const membersRepository = {
 
       if (Contents === undefined) return [];
 
-      const memberList = await Promise.all(
-        Contents.map(({ Key }) => {
-          assert(Key !== undefined);
-          const githubId = Key.split('/')[1].split('.')[0];
-          return githubId;
-        })
-      );
+      const memberList = Contents.map(({ Key }) => {
+        assert(Key !== undefined);
+        const githubId = Key.split('/')[1].split('.')[0];
+        return githubId;
+      });
 
       return memberList;
     } catch (err) {


### PR DESCRIPTION
メンバーページの実装に向けてBEの型とs3操作部分を実装

型は仮としてid, name, 卒業年, avatarUrl(opt), 自己紹介(opt)を持たせている

Repoはユーザーの追加・更新, ユーザーの取得, ユーザー一覧の取得が可能 