### PR TITLE
refactor: バックエンドの処理を改善

### DIFF
--- a/client/src/components/GitHubActivity/GitHubActivity.tsx
+++ b/client/src/components/GitHubActivity/GitHubActivity.tsx
@@ -19,7 +19,7 @@ export const GitHubActivity = ({ userId }: { userId: string }) => {
   };
 
   const fetchData = useCallback(() => {
-    if (data?.userId === userId) return;
+    if (data?.githubId === userId) return;
 
     setLoading(true);
     setError(false);

--- a/server/.env.example
+++ b/server/.env.example
@@ -5,7 +5,6 @@ CORS_ORIGIN=http://localhost:3000
 FIREBASE_AUTH_EMULATOR_HOST=localhost:9099
 FIREBASE_SERVER_KEY={}
 GITHUB_API_ORIGIN=https://github-contributions-api.jogruber.de
-GITHUB_USERNAMES=
 S3_ENDPOINT=http://localhost:9000
 S3_PUBLIC_ENDPOINT=http://localhost:9000
 S3_BUCKET=app

--- a/server/commonTypesWithClient/models.ts
+++ b/server/commonTypesWithClient/models.ts
@@ -22,7 +22,7 @@ export type GitHubActivityModel = {
     count: number;
     level: 0 | 1 | 2 | 3 | 4;
   }[];
-  userId: string;
+  githubId: string;
 };
 
 export type MemberModel = {
@@ -40,4 +40,12 @@ export type MemberModel = {
   }[];
   socialLinks?: string[];
   updateAt: number;
+};
+
+export type MemberList = {
+  members: {
+    githubId: string;
+    userName: string;
+    graduateYear: number;
+  }[];
 };

--- a/server/repository/githubActivityRepository.ts
+++ b/server/repository/githubActivityRepository.ts
@@ -3,10 +3,10 @@ import { s3Client } from '$/service/s3Client';
 import { PutObjectCommand } from '@aws-sdk/client-s3';
 
 export const githubActivityRepository = {
-  upload: async (userId: string, data: string): Promise<void> => {
+  upload: async (githubId: string, data: string): Promise<void> => {
     const params = {
       Bucket: S3_BUCKET,
-      Key: `members/${userId}/githubActivity.json`,
+      Key: `members/${githubId}/githubActivity.json`,
       Body: data,
     };
 
@@ -17,9 +17,9 @@ export const githubActivityRepository = {
       console.error(err);
     }
   },
-  fetchData: async (userId: string): Promise<string | undefined> => {
+  fetchData: async (userName: string): Promise<string | undefined> => {
     try {
-      const res = await fetch(`${GITHUB_API_ORIGIN}/v4/${userId}?y=last`);
+      const res = await fetch(`${GITHUB_API_ORIGIN}/v4/${userName}?y=last`);
       return await res.text();
     } catch (err) {
       console.error(err);

--- a/server/repository/membersRepository.ts
+++ b/server/repository/membersRepository.ts
@@ -1,4 +1,4 @@
-import type { MemberModel } from '$/commonTypesWithClient/models';
+import type { MemberList, MemberModel } from '$/commonTypesWithClient/models';
 import { S3_BUCKET } from '$/service/envValues';
 import { prismaClient } from '$/service/prismaClient';
 import { s3Client } from '$/service/s3Client';
@@ -26,13 +26,6 @@ const toMemberModel = (prismaMember: Member): MemberModel => ({
     .parse(prismaMember.products),
   updateAt: prismaMember.updatedAt.getTime(),
 });
-
-export type MemberList = {
-  members: {
-    githubId: string;
-    graduateYear: number;
-  }[];
-};
 
 export const membersRepository = {
   saveToDB: async (member: MemberModel): Promise<MemberModel | null> => {

--- a/server/service/envValues.ts
+++ b/server/service/envValues.ts
@@ -14,7 +14,6 @@ const S3_BUCKET = process.env.S3_BUCKET ?? '';
 const S3_ACCESS_KEY = process.env.S3_ACCESS_KEY ?? '';
 const S3_SECRET_KEY = process.env.S3_SECRET_KEY ?? '';
 const GITHUB_API_ORIGIN = process.env.GITHUB_API_ORIGIN ?? '';
-const GITHUB_USERNAMES = process.env.GITHUB_USERNAMES?.split(',') ?? [];
 
 export {
   API_BASE_PATH,
@@ -23,7 +22,6 @@ export {
   FIREBASE_AUTH_EMULATOR_HOST,
   FIREBASE_SERVER_KEY,
   GITHUB_API_ORIGIN,
-  GITHUB_USERNAMES,
   PORT,
   S3_ACCESS_KEY,
   S3_BUCKET,

--- a/server/usecase/githubActivityUseCase.ts
+++ b/server/usecase/githubActivityUseCase.ts
@@ -1,18 +1,28 @@
-import type { GitHubActivityModel } from '$/commonTypesWithClient/models';
-import { GITHUB_USERNAMES } from '$/service/envValues';
+import type { GitHubActivityModel, MemberList } from 'commonTypesWithClient/models';
 import { githubActivityRepository } from '../repository/githubActivityRepository';
+import { membersRepository } from './../repository/membersRepository';
 
-const fetchActivity = async (userId: string): Promise<GitHubActivityModel> => {
-  const data = await githubActivityRepository.fetchData(userId);
+const fetchActivity = async (userName: string, githubId: string): Promise<GitHubActivityModel> => {
+  const data = await githubActivityRepository.fetchData(userName);
   if (data !== undefined) {
-    await githubActivityRepository.upload(userId, data);
+    await githubActivityRepository.upload(userName, data);
   }
 
-  return { ...JSON.parse(data ?? '{}'), userId };
+  return { ...JSON.parse(data ?? '{}'), githubId: userName };
 };
 
 const fetchAllActivities = async () => {
-  await Promise.all(GITHUB_USERNAMES.map(fetchActivity));
+  const MemberList: MemberList | null = await membersRepository.getListFromS3();
+  if (MemberList === null) return;
+
+  const activities = await Promise.all(
+    MemberList.members.map(async (member) => {
+      const activity = await fetchActivity(member.userName, member.githubId);
+      return activity;
+    })
+  );
+
+  return activities;
 };
 
 export const githubActivityUseCase = {

--- a/server/usecase/memberUseCase.ts
+++ b/server/usecase/memberUseCase.ts
@@ -1,5 +1,4 @@
-import type { MemberModel } from '$/commonTypesWithClient/models';
-import type { MemberList } from '$/repository/membersRepository';
+import type { MemberList, MemberModel } from '$/commonTypesWithClient/models';
 import { membersRepository } from '$/repository/membersRepository';
 
 const createMember = async (member: MemberModel): Promise<MemberModel | null> => {
@@ -9,7 +8,11 @@ const createMember = async (member: MemberModel): Promise<MemberModel | null> =>
   ]);
 
   const memberList: MemberList = (await membersRepository.getListFromS3()) ?? { members: [] };
-  memberList.members.push({ githubId: member.githubId, graduateYear: member.graduateYear });
+  memberList.members.push({
+    githubId: member.githubId,
+    userName: member.userName,
+    graduateYear: member.graduateYear,
+  });
 
   await membersRepository.saveListToS3(memberList);
 
@@ -29,7 +32,11 @@ const updateMember = async (member: MemberModel): Promise<MemberModel | null> =>
   const newMemberList: MemberList = {
     members: memberList.members.map((member) => {
       if (member.githubId === updatedMember.githubId) {
-        return { githubId: member.githubId, graduateYear: updatedMember.graduateYear };
+        return {
+          githubId: member.githubId,
+          userName: member.userName,
+          graduateYear: updatedMember.graduateYear,
+        };
       }
       return member;
     }),


### PR DESCRIPTION
以前のプルリクでDBのスキーマとtsの型が変更されたので、githubIdとuserNameをしっかりと区別した。
githubId: githubの内部で管理されている数字のid
userName: githubの一意のユーザーネーム (ex: mst-mkt)

------
S3からメンバー一覧を取得できるようになったので、.envからGITHUB_MEMBERSを削除しました。