### PR TITLE
CORS_ORIGINを複数に

### DIFF
--- a/server/.env.example
+++ b/server/.env.example
@@ -1,7 +1,7 @@
 PORT=31577
 API_BASE_PATH=/api
 API_ORIGIN=http://localhost:31577
-CORS_ORIGIN=http://localhost:3001
+CORS_ORIGIN=http://localhost:3001,http://localhost:3000
 FIREBASE_AUTH_EMULATOR_HOST=localhost:9099
 FIREBASE_SERVER_KEY={}
 GITHUB_API_ORIGIN=https://github-contributions-api.jogruber.de

--- a/server/service/envValues.ts
+++ b/server/service/envValues.ts
@@ -5,7 +5,7 @@ dotenv.config();
 const PORT = +(process.env.PORT ?? '8080');
 const API_BASE_PATH = process.env.API_BASE_PATH ?? '';
 const API_ORIGIN = process.env.API_ORIGIN ?? '';
-const CORS_ORIGIN = process.env.CORS_ORIGIN ?? '';
+const CORS_ORIGIN = process.env.CORS_ORIGIN?.split(',') ?? [];
 const FIREBASE_AUTH_EMULATOR_HOST = process.env.FIREBASE_AUTH_EMULATOR_HOST;
 const FIREBASE_SERVER_KEY = process.env.FIREBASE_SERVER_KEY ?? '';
 const S3_ENDPOINT = process.env.S3_ENDPOINT ?? '';


### PR DESCRIPTION
## 内容

`localhost:3000`と`localhost:3001`でapiを叩けるように、複数指定できるようにしました

## 変更点

- .env.sampleを編集
- envValues.tsでCORS_ORIGINを配列に

## 関連 Issue


## スクリーンショット・動画など


## その他
