### PR TITLE
add: カラーパレットをINIAD.ts用に

### DIFF
--- a/docusaurus/src/css/custom.css
+++ b/docusaurus/src/css/custom.css
@@ -6,25 +6,29 @@
 
 /* You can override the default Infima variables here. */
 :root {
-  --ifm-color-primary: #2e8555;
-  --ifm-color-primary-dark: #29784c;
-  --ifm-color-primary-darker: #277148;
-  --ifm-color-primary-darkest: #205d3b;
-  --ifm-color-primary-light: #33925d;
-  --ifm-color-primary-lighter: #359962;
-  --ifm-color-primary-lightest: #3cad6e;
+  --ifm-background-color: #f8f8fc;
+  --ifm-background-surface-color: #ffffff;
+  --ifm-color-primary: #3dafe3;
+  --ifm-color-primary-dark: #209fda;
+  --ifm-color-primary-darker: #128fc9;
+  --ifm-color-primary-darkest: #0d83ba;
+  --ifm-color-primary-light: #51bced;
+  --ifm-color-primary-lighter: #70c5ed;
+  --ifm-color-primary-lightest: #7dd0f6;
   --ifm-code-font-size: 95%;
   --docusaurus-highlighted-code-line-bg: rgba(0, 0, 0, 0.1);
 }
 
 /* For readability concerns, you should choose a lighter palette in dark mode. */
 [data-theme='dark'] {
-  --ifm-color-primary: #25c2a0;
-  --ifm-color-primary-dark: #21af90;
-  --ifm-color-primary-darker: #1fa588;
-  --ifm-color-primary-darkest: #1a8870;
-  --ifm-color-primary-light: #29d5b0;
-  --ifm-color-primary-lighter: #32d8b4;
-  --ifm-color-primary-lightest: #4fddbf;
+  --ifm-background-color: #333333;
+  --ifm-background-surface-color: #424242;
+  --ifm-color-primary: #3f7bc5;
+  --ifm-color-primary-dark: #296bbb;
+  --ifm-color-primary-darker: #0c55ae;
+  --ifm-color-primary-darkest: #004293;
+  --ifm-color-primary-light: #4b8bdb;
+  --ifm-color-primary-lighter: #619ee9;
+  --ifm-color-primary-lightest: #77abea;
   --docusaurus-highlighted-code-line-bg: rgba(0, 0, 0, 0.3);
 }


### PR DESCRIPTION
## 内容

DocusaurusのデフォルトのカラーパレットからINIAD.ts用に変更しました。
ライトテーマはINIADのロゴから、ダークテーマはTypeScriptのロゴから色を取りました。

## 変更点

<!-- このセクションでは、具体的な変更点や修正箇所を箇条書きでリストアップしてください。
- 変更点 1
- 変更点 2
- 変更点 3 -->

## 関連 Issue

<!--
関連するIssue番号を記載してください。
番号の前に"close"を書くとPRがマージされた際に自動的にIssueが閉じられます。
（例）
ref #0
close #0
-->

## スクリーンショット・動画など

![スクリーンショット 2023-08-28 204109](https://github.com/INIAD-Developers/INIADts-jobsite/assets/131662659/2975897d-6910-4ed4-92f7-2095f3a0d74e)
![スクリーンショット 2023-08-28 204117](https://github.com/INIAD-Developers/INIADts-jobsite/assets/131662659/13c26527-4687-4a7c-882c-e0747b846878)


## その他
