### PR TITLE
メンバーアイコンを並べたコンポ―ネット作成

### DIFF
--- a/docusaurus/src/components/MemberIcons/MemberIcons.module.css
+++ b/docusaurus/src/components/MemberIcons/MemberIcons.module.css
@@ -1,0 +1,9 @@
+.container {
+  height: 100%;
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(40px, 1fr));
+}
+
+.member img {
+  border-radius: 50%;
+}

--- a/docusaurus/src/components/MemberIcons/MemberIcons.tsx
+++ b/docusaurus/src/components/MemberIcons/MemberIcons.tsx
@@ -1,0 +1,20 @@
+import { members } from '@site/src/data/members';
+import React from 'react';
+import styles from './MemberIcons.module.css';
+
+export const MemberIcons = () => {
+  return (
+    <div className={styles.container}>
+      {members.map((member, i) => (
+        <div key={i} className={styles.member}>
+          <a href={`imokencomponent/${member.userName}`}>
+            <img
+              src={`https://avatars.githubusercontent.com/${member.userName}`}
+              alt={`${member}'s image`}
+            />
+          </a>
+        </div>
+      ))}
+    </div>
+  );
+};

--- a/docusaurus/src/components/MemberIcons/MemberIcons.tsx
+++ b/docusaurus/src/components/MemberIcons/MemberIcons.tsx
@@ -1,3 +1,4 @@
+import Link from '@docusaurus/Link';
 import { members } from '@site/src/data/members';
 import React from 'react';
 import styles from './MemberIcons.module.css';
@@ -7,12 +8,12 @@ export const MemberIcons = () => {
     <div className={styles.container}>
       {members.map((member, i) => (
         <div key={i} className={styles.member}>
-          <a href={`imokencomponent/${member.userName}`}>
+          <Link to={`members/${member.userName}`}>
             <img
               src={`https://avatars.githubusercontent.com/${member.userName}`}
               alt={`${member}'s image`}
             />
-          </a>
+          </Link>
         </div>
       ))}
     </div>

--- a/docusaurus/src/data/members.ts
+++ b/docusaurus/src/data/members.ts
@@ -56,4 +56,58 @@ export const members: Member[] = [
     graduateYear: 2027,
     socialLinks: ['https://github.com/yossuli'],
   },
+  {
+    userName: 'g-ratie',
+    displayName: 'ラティ',
+    graduateYear: 2026,
+    socialLinks: ['https://github.com/g-ratie'],
+  },
+  {
+    userName: 'mst-mkt',
+    displayName: '🧶',
+    graduateYear: 2027,
+    socialLinks: ['https://github.com/mst-mkt'],
+  },
+  {
+    userName: 'yossuli',
+    displayName: 'yossuli',
+    graduateYear: 2027,
+    socialLinks: ['https://github.com/yossuli'],
+  },
+  {
+    userName: 'g-ratie',
+    displayName: 'ラティ',
+    graduateYear: 2026,
+    socialLinks: ['https://github.com/g-ratie'],
+  },
+  {
+    userName: 'mst-mkt',
+    displayName: '🧶',
+    graduateYear: 2027,
+    socialLinks: ['https://github.com/mst-mkt'],
+  },
+  {
+    userName: 'yossuli',
+    displayName: 'yossuli',
+    graduateYear: 2027,
+    socialLinks: ['https://github.com/yossuli'],
+  },
+  {
+    userName: 'g-ratie',
+    displayName: 'ラティ',
+    graduateYear: 2026,
+    socialLinks: ['https://github.com/g-ratie'],
+  },
+  {
+    userName: 'mst-mkt',
+    displayName: '🧶',
+    graduateYear: 2027,
+    socialLinks: ['https://github.com/mst-mkt'],
+  },
+  {
+    userName: 'yossuli',
+    displayName: 'yossuli',
+    graduateYear: 2027,
+    socialLinks: ['https://github.com/yossuli'],
+  },
 ];

--- a/docusaurus/src/pages/index.tsx
+++ b/docusaurus/src/pages/index.tsx
@@ -2,6 +2,7 @@ import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
 import Layout from '@theme/Layout';
 import React from 'react';
 import { Carousel } from '../components/Carousel/Carousel';
+import { MemberIcons } from '../components/MemberIcons/MemberIcons';
 import { products } from '../data/products';
 import styles from './index.module.css';
 
@@ -47,6 +48,7 @@ const Home = (): JSX.Element => {
         </div>
         <div className={styles.members}>
           <h2 className={styles.contentTitle}>メンバー</h2>
+          <MemberIcons />
           <div />
         </div>
       </div>


### PR DESCRIPTION
## 内容

メンバーのアイコンを並べたコンポーネントを作成

## 変更点

- メンバーのアイコンを並べたコンポーネントを作成
- アイコンクリックで個人ページに移動

## 関連 Issue

<!--
close #105
-->

## スクリーンショット

![スクリーンショット 2023-08-29 033123](https://github.com/INIAD-Developers/INIADts-jobsite/assets/131968392/c8c81822-223b-4427-9746-bd2023b96c89)

## その他