### PR TITLE
メンバー一覧をソート可能に

### DIFF
--- a/client/src/components/Banner/Banner.module.css
+++ b/client/src/components/Banner/Banner.module.css
@@ -7,7 +7,7 @@
   height: calc(100svh - var(--ifm-navbar-height));
   padding: 4svmin;
   overflow: hidden;
-  background-image: linear-gradient(135deg, #1b2033 0%, #3c314c 30%, #172943 70%, #10121b 100%);
+  background-image: linear-gradient(135deg, #090a10 0%, #090f29 30%, #060c15 70%, #10121b 100%);
 }
 
 .logos {
@@ -55,6 +55,9 @@
   height: 1rem;
   content: '';
   background-color: #fff;
+}
+
+.typing.typingAnim::after {
   animation: typing 1.2s steps(1) infinite;
 }
 

--- a/client/src/components/Banner/Banner.tsx
+++ b/client/src/components/Banner/Banner.tsx
@@ -23,7 +23,9 @@ export const Banner = () => {
 
         clearInterval(typingIntervalID);
 
+        subTitleElm.classList.add(styles.typingAnim);
         setTimeout(() => {
+          subTitleElm.classList.remove(styles.typingAnim);
           subTitleElm.classList.remove(styles.typing);
         }, 3000);
       }

--- a/client/src/pages/members/index.module.css
+++ b/client/src/pages/members/index.module.css
@@ -6,23 +6,68 @@
 
 .title {
   display: flex;
-  flex-direction: column;
+  flex-direction: row;
   grid-column: 2;
+  gap: 4svmin;
   margin: 8svmin 0 6svmin;
 }
 
 .title > h1 {
+  flex: 1 1 100%;
   margin: 0;
   font-size: 2.4rem;
   line-height: 3rem;
 }
 
-.title > p {
+.title p {
   margin: 0;
   font-size: 1.2rem;
   font-weight: bold;
   line-height: 2rem;
   color: var(--ifm-color-primary);
+}
+
+.title > .select {
+  position: relative;
+  flex: 0 0 fit-content;
+  height: 2.4rem;
+}
+
+.title > .select > select {
+  height: 100%;
+  padding: 0 3rem 0 1rem;
+  font-size: 0.8rem;
+  cursor: pointer;
+  background-color: var(--ifm-background-surface-color);
+  border: 0;
+  border-radius: 0.4rem;
+  appearance: none;
+}
+
+.title > .select::after {
+  position: absolute;
+  top: calc(50% - 0.1rem);
+  right: 0.8rem;
+  width: 0.6rem;
+  height: 0.2rem;
+  pointer-events: none;
+  content: '';
+  background-color: #fff;
+  border-radius: 0.1rem;
+  transform: translateX(calc(-0.2rem / 1.414)) rotate(45deg);
+}
+
+.title > .select::before {
+  position: absolute;
+  top: calc(50% - 0.1rem);
+  right: 0.8rem;
+  width: 0.6rem;
+  height: 0.2rem;
+  pointer-events: none;
+  content: '';
+  background-color: #fff;
+  border-radius: 0.1rem;
+  transform: translateX(calc(0.2rem / 1.414)) rotate(-45deg);
 }
 
 .main {

--- a/client/src/pages/members/index.module.css
+++ b/client/src/pages/members/index.module.css
@@ -24,7 +24,14 @@
   font-size: 1.2rem;
   font-weight: bold;
   line-height: 2rem;
-  color: var(--ifm-color-primary);
+  color: transparent;
+  background-image: linear-gradient(
+    135deg,
+    var(--ifm-color-primary-lightest) 0%,
+    var(--ifm-color-primary) 40%,
+    var(--ifm-color-primary-darker) 100%
+  );
+  background-clip: text;
 }
 
 .title > .select {

--- a/client/src/pages/members/index.tsx
+++ b/client/src/pages/members/index.tsx
@@ -1,26 +1,48 @@
 import Link from '@docusaurus/Link';
+import MemberCard from '@site/src/components/MemberCard/MemberCard';
 import { members } from '@site/src/data/members';
 import Layout from '@theme/Layout';
-import React, { useCallback, useMemo } from 'react';
-import MemberCard from '../../components/MemberCard/MemberCard';
+import React, { useCallback, useMemo, useState } from 'react';
+import type { Member } from '../../../src/types/type';
 import styles from './index.module.css';
 
+type SortBy = 'grade-asc' | 'grade-desc' | 'findy-asc' | 'findy-desc';
+
+const sortingText: Record<SortBy, string> = {
+  'grade-asc': '学年昇順',
+  'grade-desc': '学年降順',
+  'findy-asc': 'スキル偏差値昇順',
+  'findy-desc': 'スキル偏差値降順',
+};
+
+type Grade = {
+  grade: number;
+  members: Member[];
+};
+
+type MemberList = Member[] | Grade[];
+
 const Members = () => {
-  const memberList = useMemo(() => {
+  const [sortBy, setSortBy] = useState<SortBy>('grade-asc');
+
+  const memberList = useMemo<MemberList>(() => {
     const gradeList = Array.from(new Set(members.map((member) => member.graduateYear))).sort(
-      (a, b) => b - a
+      (a, b) => (sortBy === 'grade-asc' ? b - a : a - b)
     );
 
-    const memberList = gradeList.map((grade) => {
-      const gradeMembers = members.filter((member) => member.graduateYear === grade);
-      return {
-        grade,
-        members: gradeMembers,
-      };
-    });
-
-    return memberList;
-  }, []);
+    switch (sortBy) {
+      case 'grade-asc':
+      case 'grade-desc':
+        return gradeList.map((grade) => ({
+          grade,
+          members: members.filter((member) => member.graduateYear === grade),
+        }));
+      case 'findy-asc':
+        return members.sort((a, b) => (b.findy ?? 0) - (a.findy ?? 0));
+      case 'findy-desc':
+        return members.sort((a, b) => (a.findy ?? 0) - (b.findy ?? 0));
+    }
+  }, [sortBy]);
 
   const computeGrade = useCallback((graduateYear: number) => {
     const isBetweenJanAndMar = new Date().getMonth() + 1 <= 3;
@@ -29,32 +51,64 @@ const Members = () => {
     return currentGrade;
   }, []);
 
+  const handleSortSelect = useCallback((e: React.ChangeEvent<HTMLSelectElement>) => {
+    setSortBy(e.target.value as SortBy);
+  }, []);
+
   return (
     <Layout title="Members">
       <div className={styles.container}>
         <div className={styles.title}>
-          <h1>メンバー一覧</h1>
-          <p>Members</p>
+          <h1>
+            メンバー一覧
+            <p>Members</p>
+          </h1>
+          <div className={styles.select}>
+            <select onChange={handleSortSelect}>
+              {Object.entries(sortingText).map(([key, value]) => (
+                <option
+                  key={key}
+                  value={key}
+                  selected={key === sortBy}
+                  onClick={() => setSortBy(key as SortBy)}
+                >
+                  {value}
+                </option>
+              ))}
+            </select>
+          </div>
         </div>
         <main className={styles.main}>
-          <ul className={styles.members}>
-            {memberList.map((grade) => (
-              <li key={grade.grade} className={styles.grade}>
-                <h2 id={`${grade.grade}`}>
-                  <a href={`#${grade.grade}`}>{computeGrade(grade.grade)}年生</a>
-                </h2>
-                <ul className={styles.memberList}>
-                  {grade.members.map((member, i) => (
-                    <li key={`${member.userName}-${i}`} className={styles.member}>
-                      <Link to={`/members/${member.userName}`}>
-                        <MemberCard member={member} count={i} />
-                      </Link>
-                    </li>
-                  ))}
-                </ul>
-              </li>
-            ))}
-          </ul>
+          {'grade' in memberList[0] ? (
+            <ul className={styles.members}>
+              {(memberList as Grade[]).map((grade) => (
+                <li key={grade?.grade} className={styles.grade}>
+                  <h2 id={`${grade.grade}`}>
+                    <a href={`#${grade.grade}`}>{computeGrade(grade.grade)}年生</a>
+                  </h2>
+                  <ul className={styles.memberList}>
+                    {grade.members.map((member, i) => (
+                      <li key={`${member.userName}-${i}`} className={styles.member}>
+                        <Link to={`/members/${member.userName}`}>
+                          <MemberCard member={member} count={i} />
+                        </Link>
+                      </li>
+                    ))}
+                  </ul>
+                </li>
+              ))}
+            </ul>
+          ) : (
+            <ul className={`${styles.memberList} ${styles.members}`}>
+              {(memberList as Member[]).map((member, i) => (
+                <li key={`${member.userName}-${i}`} className={styles.member}>
+                  <Link to={`/members/${member.userName}`}>
+                    <MemberCard member={member} count={i} />
+                  </Link>
+                </li>
+              ))}
+            </ul>
+          )}
         </main>
       </div>
     </Layout>


### PR DESCRIPTION
## 内容

メンバー一覧のページでメンバーのソートを可能にしました

## 変更点

- ソート可能に
- ソート方法によって若干構造を変更

## 関連 Issue

<!--
関連するIssue番号を記載してください。
番号の前に"close"を書くとPRがマージされた際に自動的にIssueが閉じられます。
（例）
ref #0
close #0
-->

## スクリーンショット・動画など

![image](https://github.com/INIAD-Developers/INIADts-jobsite/assets/131662659/abf72a17-dcba-431d-b251-fea4307fa0c6)
## その他
